### PR TITLE
Added Function to generate Java Object after Filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,13 @@ Issue object = new Issue();         // replace this with your object/collection/
 System.out.println(SquigglyUtils.stringify(objectMapper, object));
 ```
 
+Also, you can generate a Plain Old Java Object (POJO) instead of a JSON String
+
+```java
+ObjectMapper objectMapper = Squiggly.init(new ObjectMapper(), "assignee{firstName}");
+System.out.println(SquigglyUtils.objectify(objectMapper, object, Object.class));
+```
+
 ## <a name="reference-object"></a>Reference Object
 
 For the filtering examples, let's use an the example object of type Issue

--- a/src/main/java/com/github/bohnman/squiggly/util/SquigglyUtils.java
+++ b/src/main/java/com/github/bohnman/squiggly/util/SquigglyUtils.java
@@ -39,7 +39,7 @@ public class SquigglyUtils {
      * @return Java Object
 	 */
 	
-	public static <T> T objectify(ObjectMapper mapper, Object object, Class<T> classType) {
+	public static <T> T objectify(ObjectMapper mapper, Object object, Class<T> classType)  {
 		try {
 			return mapper.readValue(mapper.writeValueAsBytes(object), classType);
 		} catch (Exception e) {

--- a/src/main/java/com/github/bohnman/squiggly/util/SquigglyUtils.java
+++ b/src/main/java/com/github/bohnman/squiggly/util/SquigglyUtils.java
@@ -1,9 +1,8 @@
 package com.github.bohnman.squiggly.util;
 
-import java.io.IOException;
-
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+
 import net.jcip.annotations.ThreadSafe;
 
 /**
@@ -40,7 +39,11 @@ public class SquigglyUtils {
      * @return Java Object
 	 */
 	
-	private static <T> T objectify(ObjectMapper mapper, Object object, Class<T> classType) throws IOException, ClassNotFoundException {
-		return mapper.readValue(mapper.writeValueAsBytes(object), classType);
+	public static <T> T objectify(ObjectMapper mapper, Object object, Class<T> classType) {
+		try {
+			return mapper.readValue(mapper.writeValueAsBytes(object), classType);
+		} catch (Exception e) {
+			throw new RuntimeException(e);
+		}
 	}
 }

--- a/src/main/java/com/github/bohnman/squiggly/util/SquigglyUtils.java
+++ b/src/main/java/com/github/bohnman/squiggly/util/SquigglyUtils.java
@@ -1,5 +1,7 @@
 package com.github.bohnman.squiggly.util;
 
+import java.io.IOException;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import net.jcip.annotations.ThreadSafe;
@@ -28,4 +30,17 @@ public class SquigglyUtils {
             throw new IllegalArgumentException(e);
         }
     }
+    
+    /*
+	 * Takes an object, Class Type and converts it to a object.
+     *
+     * @param mapper the object mapper
+     * @param object the object to convert
+     * @param classType the ClassType to convert
+     * @return Java Object
+	 */
+	
+	private static <T> T objectify(ObjectMapper mapper, Object object, Class<T> classType) throws IOException, ClassNotFoundException {
+		return mapper.readValue(mapper.writeValueAsBytes(object), classType);
+	}
 }


### PR DESCRIPTION
Instead of generating JSON String after the `init() method`
```
ObjectMapper objectMapper = Squiggly.init(new ObjectMapper(), filter);
String json = SquigglyUtils.stringify(objectMapper, someObject);
```
New  `objectify` method will be able to generate Plain Old Java Object after executing the `init() method`
```
ObjectMapper objectMapper = Squiggly.init(new ObjectMapper(), filter);
SomeObject obj = SquigglyUtils.objectify(objectMapper, someObject, SomeObject.class);
```